### PR TITLE
fix: add package.json exports types entry for .d.ts ESM types

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,12 @@
   "module": "./dist/index.esm.js",
   "exports": {
     ".": {
+      "types": {
+        "import": "./dist/index.d.ts",
+        "require": "./dist/index.d.cts"
+      },
       "import": "./dist/index.esm.js",
-      "require": "./dist/index.cjs",
-      "types": "./dist/index.d.cts"
+      "require": "./dist/index.cjs"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Overview

Adds an explicit `package.json` `"exports"` entry for `"types"`, telling TypeScript to use `dist/index.d.ts` for ESM consumers instead of the CJS `dist/index.d.cts`. ESM consumers will now have the correct type system representation of the package.

### Explanation

A `*.cts` extension indicates a file is a CJS-style one. When an ESM file `import`s a CJS one, the CJS file's exported stuff will all be available as properties of a `default` object:

```js
// source.cjs
module.exports.abc = "hello";
module.exports.default = "world";
```

```js
// index-default-import.mjs
import source from "./source.cjs";
source.abc; // "hello"
source.default; // "world"
```

```js
// index-namespace-import.mjs
import * as source from "./source.cjs";
source.default.abc; // "hello"
source.default.default; // "world"
```

That's why TypeScript was telling ESM consumers that the `LoopsClient` from `import LoopsClient from "loops"` didn't have any construct signatures. TypeScript thought that that imported value was a module object with a `default` property - not the class itself.

In other words, the `.d.cts` extension in `dist/index.d.cts` made TypeScript think they'd need to use the imported stuff like:

```ts
import LoopsClient from "loops";
new LoopsClient.default("...");
```

This PR fixes that by splitting the `"exports"` `"types"` into two files: the `.d.cts` for CJS consumers and the `.d.ts` for ESM consumers.

You can verify this fix works by running `npx @arethetypeswrong/cli . --pack` locally.

```plaintext
 No problems found 🌟


┌───────────────────┬──────────┐
│                   │ "loops"  │
├───────────────────┼──────────┤
│ node10            │ 🟢       │
├───────────────────┼──────────┤
│ node16 (from CJS) │ 🟢 (CJS) │
├───────────────────┼──────────┤
│ node16 (from ESM) │ 🟢 (ESM) │
├───────────────────┼──────────┤
│ bundler           │ 🟢       │
└───────────────────┴──────────┘
```