### PR TITLE
Change _makeQuery from private to protected and export QueryOptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -685,4 +685,5 @@ export {
   TransactionalEmail,
   ListTransactionalsResponse,
   MailingLists,
+  QueryOptions,
 };


### PR DESCRIPTION
# Pull Request

## Description

This PR changes the `_makeQuery` function from `private` to `protected` to allow the `LoopsClient` to be extended and `_makeQuery` to be enhanced. It also exports the `QueryOptions` interface.

For example:

```ts
import { LoopsClient as ActualLoopsClient, QueryOptions } from 'loops';

import { logger } from '@/utils/logger';

export class LoopsClient extends ActualLoopsClient {
  async _makeQuery<T>(options: QueryOptions): Promise<T> {
    try {
      return await super._makeQuery<T>(options);
    } catch (error) {
      logger.error('Error making loops query', {
        options,
        error,
      });
      throw error;
    }
  }
}
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

N/A

## Checklist:

Before you submit this PR, please check off items you have completed:

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context
